### PR TITLE
Change Awesome Bar Gauge color to blues

### DIFF
--- a/grafana/git-sync-demo-dashboard.json
+++ b/grafana/git-sync-demo-dashboard.json
@@ -60,7 +60,7 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "mode": "continuous-reds"
+              "mode": "continuous-blues"
             },
             "mappings": [],
             "thresholds": {


### PR DESCRIPTION
## Summary
Changed the color scheme of the "Awesome Bar Gauge" panel from `continuous-reds` to `continuous-blues` to provide a different visual appearance.

## Changes Made
- Updated the `fieldConfig.defaults.color.mode` property from `"continuous-reds"` to `"continuous-blues"` in panel ID 1
- This change affects only the visual appearance of the bar gauge panel
- No functional changes to the dashboard logic or data queries

## Testing
- [x] Verified JSON syntax is valid
- [x] Confirmed only the color mode property was changed
- [x] Dashboard structure remains intact

This demonstrates how easy it is to make visual changes to Grafana dashboards through Git workflows! 🎨